### PR TITLE
fix(object-destruct): rules fix for unicorn and eslint fixes #22

### DIFF
--- a/base.js
+++ b/base.js
@@ -26,5 +26,13 @@ module.exports = {
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
     'no-underscore-dangle': 0,
     'promise/avoid-new': 0,
+    'prefer-destructuring': [
+      "error",
+      {
+        'object': true,
+        'array': false
+      }
+    ]
+
   },
 };

--- a/test.js
+++ b/test.js
@@ -42,6 +42,9 @@ function foo(bar) {
     bar = 13;
 }
 
+// array destructuring
+var foo = array[0];
+
 // no-shadow
 var a = 3;
 function b() {
@@ -81,6 +84,7 @@ const fn = () =>  {
 
     // Disabled
     expect(find(errors, { ruleId: 'no-param-reassign/sort-comp' })).toBeUndefined();
+    expect(find(errors, { ruleId: 'prefer-destructuring'})).toBeUndefined();
     expect(find(errors, { ruleId: 'class-methods-use-this' })).toBeUndefined();
     expect(find(errors, { ruleId: 'no-plusplus' })).toBeUndefined();
     expect(find(errors, { ruleId: 'no-underscore-dangle' })).toBeUndefined();


### PR DESCRIPTION
eslint and eslint-plugin-unicorn have 2 rules both for object/array restructuring. To correct this I put the recommended settings from the README below to keep the same recommended settings as unicorn's. fixes #22 

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/62c51a7e91c828f866b9489c10ecbef710722608/docs/rules/no-unreadable-array-destructuring.md#note