### PR TITLE
fix: fixed file not being uploaded to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "files": [
     "index.js",
     "browser.js",
+    "ts-recommended.js",
     "base.js",
     "README.md"
   ],


### PR DESCRIPTION
`ts-recommended` was not being copied over to npm when we published so the linter found fail to find it.