### PR TITLE
refactor: removed node env from eslint config

### DIFF
--- a/base.js
+++ b/base.js
@@ -22,8 +22,7 @@ module.exports = {
   },
 
   env: {
-    jest: true,
-    node: true,
+    jest: true
   },
 
   overrides: [

--- a/browser.js
+++ b/browser.js
@@ -14,8 +14,7 @@ module.exports = {
   env: {
     browser: true,
     jest: true,
-    es6: true,
-    node: false,
+    es6: true
   },
 
   // FIXME: how to test?


### PR DESCRIPTION
Adding explicit use of `node` to `false` will not allow web apps like `CRA` to use node-like things. Removed this to stop failing builds due to linter errors.