### PR TITLE
refactor: added jest globals env

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -14,6 +14,7 @@ module.exports = {
   env: {
     browser: true,
     jest: true,
+    "jest/globals": true,
     es6: true
   },
 


### PR DESCRIPTION
Allows `global.window` overrides for jest unit tests to work when using `availity/browser`