### PR TITLE
refactor: allow jsx in tsx files and allow some expression types in tsx

### DIFF
--- a/base.js
+++ b/base.js
@@ -42,13 +42,7 @@ module.exports = {
       rules: Object.assign(recommendedTs, prettierTs.rules, {
         '@typescript-eslint/no-unused-vars': 'off',
       }),
-    },
-    {
-      files: ['**/*.tsx'],
-      rules: {
-        'react/prop-types': 'off',
-      },
-    },
+    }
   ],
 
   rules: {

--- a/base.js
+++ b/base.js
@@ -43,6 +43,12 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': 'off',
       }),
     },
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
   ],
 
   rules: {

--- a/browser.js
+++ b/browser.js
@@ -54,7 +54,7 @@ module.exports = {
     ...base.rules,
     'unicorn/no-for-loop': 0,
     'react/sort-comp': 0,
-    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx','.tsx'] }],
     'react/require-default-props': 0,
     'react-hooks/rules-of-hooks': 'warn',
     'react-hooks/exhaustive-deps': 'warn',

--- a/browser.js
+++ b/browser.js
@@ -48,16 +48,25 @@ module.exports = {
     __STAGING__: true,
   },
 
-  overrides: base.overrides,
+  overrides: [
+    ...base.overrides,
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
+  ],
 
   rules: {
     ...base.rules,
     'unicorn/no-for-loop': 0,
     'react/sort-comp': 0,
-    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx','.tsx'] }],
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx', '.tsx'] }],
     'react/require-default-props': 0,
     'react-hooks/rules-of-hooks': 'warn',
     'react-hooks/exhaustive-deps': 'warn',
+    'react/jsx-props-no-spreading': 0,
     'react/forbid-prop-types': [
       'error',
       {

--- a/tests/react-typescript.js
+++ b/tests/react-typescript.js
@@ -11,4 +11,14 @@ class Foo<F = String> extends Bar<String> implements Baz<String> {
 
 // testing no-unused-vars
 const hello: String  = "World";
+
+interface HelloProps {
+  world: string;
+};
+
+const SomeComp = props => <div {...props} />
+
+const Hello: React.SFC<HelloProps> = ({ world, ...props }) => (
+  <div>Hello {world}<SomeComp {...props} /></div>
+);
 `;

--- a/tests/test.js
+++ b/tests/test.js
@@ -59,5 +59,7 @@ describe('rules', () => {
     const errors = runEslint(reactTsString(), reactConf, 'example.tsx');
     expect(find(errors, { ruleId: '@typescript-eslint/ban-types' })).toBeDefined();
     expect(find(errors, { ruleId: '@typescript-eslint/no-unused-vars' })).toBeUndefined();
+    expect(find(errors, { ruleId: 'react/prop-types'})).toBeUndefined();
+    expect(find(errors, { ruleId: 'react/jsx-props-no-spreading'})).toBeUndefined();
   });
 });

--- a/ts-recommended.js
+++ b/ts-recommended.js
@@ -5,7 +5,10 @@ module.exports = {
   camelcase: 'off',
   '@typescript-eslint/camelcase': 'error',
   '@typescript-eslint/class-name-casing': 'error',
-  '@typescript-eslint/explicit-function-return-type': 'warn',
+  '@typescript-eslint/explicit-function-return-type': ['warn',{
+    "allowExpressions": true,
+    "allowTypedFunctionExpressions": true
+  }],
   '@typescript-eslint/explicit-member-accessibility': 'error',
   indent: 'off',
   '@typescript-eslint/indent': 'error',


### PR DESCRIPTION
- Allows `jsx` to be written inside of `tsx` files.

- Allows explicit function return types for expressions and functional expression. IE `react`.