### PR TITLE
fix: disable unicorn/prefer-node-append

### DIFF
--- a/base.js
+++ b/base.js
@@ -43,7 +43,7 @@ module.exports = {
       rules: Object.assign(recommendedTs, prettierTs.rules, {
         '@typescript-eslint/no-unused-vars': 'off',
       }),
-    }
+    },
   ],
 
   rules: {
@@ -69,5 +69,6 @@ module.exports = {
         array: false,
       },
     ],
+    'unicorn/prefer-node-append': 0,
   },
 };

--- a/tests/base.js
+++ b/tests/base.js
@@ -55,4 +55,10 @@ const fn = () =>  {
 
 // unicorn/prefer-node-remove
 this.parentNode.removeChild(this)
+
+// unicorn/prefer-node-append
+const anchor = document.createElement('a');
+document.body.appendChild(anchor);
 `;
+
+

--- a/tests/test.js
+++ b/tests/test.js
@@ -39,6 +39,7 @@ describe('rules', () => {
     expect(find(errors, { ruleId: 'promise/avoid-new' })).toBeUndefined();
     expect(find(errors, { ruleId: 'unicorn/prefer-includes' })).toBeUndefined();
     expect(find(errors, { ruleId: 'unicorn/prefer-node-remove' })).toBeUndefined();
+    expect(find(errors, { ruleId: 'unicorn/prefer-node-append' })).toBeUndefined();
   });
 
   test('react', () => {
@@ -61,8 +62,8 @@ describe('rules', () => {
     const errors = runEslint(reactTsString(), reactConf, 'example.tsx');
     expect(find(errors, { ruleId: '@typescript-eslint/ban-types' })).toBeDefined();
     expect(find(errors, { ruleId: '@typescript-eslint/no-unused-vars' })).toBeUndefined();
-    expect(find(errors, { ruleId: 'react/prop-types'})).toBeUndefined();
-    expect(find(errors, { ruleId: 'react/jsx-props-no-spreading'})).toBeUndefined();
+    expect(find(errors, { ruleId: 'react/prop-types' })).toBeUndefined();
+    expect(find(errors, { ruleId: 'react/jsx-props-no-spreading' })).toBeUndefined();
   });
 
   test('workflow', () => {


### PR DESCRIPTION
`parentNode.append()` is not compatible with IE, which is a supported
browser at Availity. See: https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append