### PR TITLE
fix: replace core no-use-before-define with @typescript-eslint/no-use…

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -96,5 +96,8 @@ module.exports = {
         specialLink: ['to'],
       },
     ],
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2540
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': 'warn',
   },
 };


### PR DESCRIPTION
…-before-define warnings

Using the @typescript-eslint fixes false positive when importing React from react