### PR TITLE
fix: disable prop-types in tsx files

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -58,7 +58,15 @@ module.exports = {
     __STAGING__: true,
   },
 
-  overrides: [...base.overrides],
+  overrides: [
+    ...base.overrides,
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
+  ],
 
   rules: {
     ...base.rules,


### PR DESCRIPTION
This was removed, and caused an error. Adding back fix to ignore tsx files for prop-types rule