### PR TITLE
fix: add .d.ts extension to import/resolver rule

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -26,7 +26,7 @@ module.exports = {
     // Append 'ts' extensions to Airbnb 'import/resolver' setting
     'import/resolver': {
       node: {
-        extensions: ['.mjs', '.js', '.ts', '.tsx', '.json', '.jsx'],
+        extensions: ['.mjs', '.js', '.ts', '.tsx', '.d.ts', '.json', '.jsx'],
       },
     },
     // Append 'ts' extensions to Airbnb 'import/extensions' setting


### PR DESCRIPTION
Adds `.d.ts` extension to the `import/resolver` rule 