### PR TITLE
ci: upgrade actions to v6 and fix trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set Node Version
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         run: yarn
@@ -46,7 +46,7 @@ jobs:
 
       - run: yarn release --no-verify # skip lifecycle checks for automated releases
       - run: git push --tags origin
-      - run: npm publish
+      - run: npm publish --provenance
 
       - name: Create Release PR
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Set Node Version ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Changes

- Upgrade `actions/checkout` from v4.3.0 → v6.0.3
- Upgrade `actions/setup-node` from v4.4.0 → v6.4.0
- Update deploy workflow to Node 24
- Fix `npm publish` for trusted publishing (OIDC): use `--provenance` flag and remove static token

## Notes

The publish 404 error was caused by switching to npm trusted publishing without updating the workflow to use OIDC/provenance.

**Before merging**, ensure the trusted publisher is configured on npmjs.com:
- Go to https://www.npmjs.com/package/eslint-config-availity/access
- Set repository owner: `Availity`, repo: `eslint-config-availity`, workflow: `deploy.yml`