### PR TITLE
fix: scope browser config rules to JS/TS files

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6,11 +6,17 @@ import globals from 'globals';
 import { compat } from './compat.js';
 import { baseRules, tsConfigs } from './base.js';
 
+const FILE_PATTERNS = ['**/*.{js,jsx,ts,tsx}'];
+
 export default [
-  ...fixupConfigRules(compat.extends('airbnb', 'plugin:import/typescript')),
+  ...fixupConfigRules(compat.extends('airbnb', 'plugin:import/typescript')).map((config) => ({
+    ...config,
+    files: config.files || FILE_PATTERNS,
+  })),
   ...baseRules,
   {
     name: 'availity/browser',
+    files: ['**/*.{js,jsx,ts,tsx}'],
     plugins: {
       'react-hooks': reactHooksPlugin,
       '@typescript-eslint': tseslint.plugin,


### PR DESCRIPTION
Adds explicit `files` patterns to the airbnb compat rules and the main browser config block so they only apply to `**/*.{js,jsx,ts,tsx}` and don't accidentally lint non-JS files.